### PR TITLE
New `OrderAwareInterface`

### DIFF
--- a/src/Query/OrderAwareInterface.php
+++ b/src/Query/OrderAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Dhii\Storage\Query;
+
+use Dhii\Espresso\ExpressionInterface;
+
+/**
+ * Something that can define the order in which results are retrieved.
+ *
+ * @since [*next-version*]
+ */
+interface OrderAwareInterface
+{
+    /**
+     * An expression that defines the order.
+     *
+     * Typically, the expression's terms would represent the fields used for ordering, each indicating
+     * if either ascending or descending.
+     *
+     * @since [*next-version*]
+     *
+     * @return ExpressionInterface The grouping expression.
+     */
+    public function getOrder();
+}

--- a/src/Query/OrderAwareInterface.php
+++ b/src/Query/OrderAwareInterface.php
@@ -19,7 +19,7 @@ interface OrderAwareInterface
      *
      * @since [*next-version*]
      *
-     * @return ExpressionInterface The grouping expression.
+     * @return ExpressionInterface The ordering expression.
      */
     public function getOrder();
 }

--- a/src/Term/OrderTermInterface.php
+++ b/src/Term/OrderTermInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dhii\Storage\Term;
+
+/**
+ * Something that can define ordering based on an entity field.
+ *
+ * @since [*next-version*]
+ */
+interface OrderTermInterface extends EntityFieldInterface
+{
+    /**
+     * Indicates ascending order mode.
+     *
+     * @since [*next-version*]
+     */
+    const ASC = 'asc';
+
+    /**
+     * Indicates descending order mode.
+     *
+     * @since [*next-version*]
+     */
+    const DESC = 'desc';
+
+    /**
+     * Retrieves the ordering mode used.
+     *
+     * @see OrderTermInterface::ASC
+     * @see OrderTermInterface::DESC
+     * @since [*next-version*]
+     *
+     * @return int|string The ordering mode.
+     */
+    public function getOrderMode();
+}

--- a/test/functional/Query/OrderAwareInterfaceTest.php
+++ b/test/functional/Query/OrderAwareInterfaceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dhii\Storage\FuncTest\Query;
+
+/**
+ * Tests {@see \Dhii\Storage\Query\OrderAwareInterface}.
+ *
+ * @since [*next-version*]
+ */
+class OrderAwareInterfaceTest extends \Xpmock\TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Storage\\Query\\OrderAwareInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Storage\Query\OrderAwareInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->getOrder()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+    }
+}

--- a/test/functional/Term/OrderTermInterfaceTest.php
+++ b/test/functional/Term/OrderTermInterfaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Dhii\Storage\FuncTest\Term;
+
+use Dhii\Storage\Term\OrderTermInterface;
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Storage\Term\OrderTermInterface}.
+ *
+ * @since [*next-version*]
+ */
+class OrderTermInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Storage\\Term\\OrderTermInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return OrderTermInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+            ->getEntityName()
+            ->getFieldName()
+            ->getOrderMode()
+            ->evaluate()
+            ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject);
+    }
+}


### PR DESCRIPTION
Attempts to incorporate a solution for #3 

This PR adds the [`OrderAwareInterface`][1] query "feature" as well as the [`OrderTermInterface`][2] expression term for use in order expressions.

[1]: https://github.com/Dhii/storage-interface/blob/task/introduce-order-aware-interface_%233/src/Query/OrderAwareInterface.php
[2]: https://github.com/Dhii/storage-interface/blob/task/introduce-order-aware-interface_%233/src/Term/OrderTermInterface.php